### PR TITLE
Feature/json content type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molgenis/molgenis-api-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A javascript client for the molgenis api",
   "main": "dist/molgenis-api-client.es.js",
   "scripts": {

--- a/src/molgenis-api-client.js
+++ b/src/molgenis-api-client.js
@@ -10,7 +10,8 @@ const defaultOptions = {
 }
 
 const handleResponse = (response) => {
-  if (response.headers.get('content-type') === 'application/json') {
+  const contentType = response.headers.get('content-type')
+  if (contentType === 'application/json' || contentType === 'application/json; charset=utf-8') {
     return response.json().then(json => response.ok ? json : Promise.reject(json.errors[0].message))
   } else {
     return response.ok ? response : Promise.reject(response)

--- a/test/molgenis-api-client.spec.js
+++ b/test/molgenis-api-client.spec.js
@@ -43,6 +43,21 @@ describe('Client Api', () => {
       get.then(response => assertDeepEquals(response, resultBody)).then(done())
     })
 
+    it('should return the server response json when content type is json with encoding', done => {
+      const resultBody = {foo: 'bar'}
+      const response = {
+        headers: {
+          'content-type': 'application/json; charset=utf-8'
+        },
+        body: resultBody
+      }
+
+      fetchMock.get('https://test.com/molgenis-test/get-something', response)
+      const get = api.get('https://test.com/molgenis-test/get-something')
+
+      get.then(response => assertDeepEquals(response, resultBody)).then(done())
+    })
+
     it('should reject the server response when response type is not json and not ok', done => {
       fetchMock.get('https://test.com/molgenis-test/get-something-not-ok', 400)
       const get = api.get('https://test.com/molgenis-test/get-something-not-ok')


### PR DESCRIPTION
Treat response with content type 'application/json; charset=utf-8' as json.

By default the express framework uses 'application/json; charset=utf-8' as conten-type for json response. To handle json response from express out of the box the api should treat this as json.