### PR TITLE
allow white space in content-type response header as per spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molgenis/molgenis-api-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A javascript client for the molgenis api",
   "main": "dist/molgenis-api-client.es.js",
   "scripts": {

--- a/src/molgenis-api-client.js
+++ b/src/molgenis-api-client.js
@@ -15,9 +15,18 @@ const handleJobResponse = response => {
   return response.text().then(text => response.ok ? text : Promise.reject(response))
 }
 
-const handleResponse = (response) => {
+const isJsonResponse = (response) => {
   const contentType = response.headers.get('content-type')
-  if (contentType === 'application/json' || contentType === 'application/json; charset=utf-8') {
+    if (!contentType) {
+      return false
+    }
+    // Ignore case, whitespace and double quotes around charset as per http spec (https://tools.ietf.org/html/rfc7231#section-3.1.1.5)
+    const normalizedContentType = contentType.toLowerCase().split(' ').join('').split('"').join('')
+    return normalizedContentType === 'application/json' || normalizedContentType === 'application/json;charset=utf-8'
+}
+
+const handleResponse = (response) => {
+  if (isJsonResponse(response)) {
     return response.json().then(json => response.ok ? json : Promise.reject(json.errors[0].message))
   } else {
     return response.ok ? response : Promise.reject(response)

--- a/test/molgenis-api-client.spec.js
+++ b/test/molgenis-api-client.spec.js
@@ -47,7 +47,7 @@ describe('Client Api', () => {
       const resultBody = {foo: 'bar'}
       const response = {
         headers: {
-          'content-type': 'application/json; charset=utf-8'
+          'content-type': 'application/JSON; charset="utf-8"'
         },
         body: resultBody
       }
@@ -56,6 +56,21 @@ describe('Client Api', () => {
       const get = api.get('https://test.com/molgenis-test/get-something')
 
       get.then(response => assertDeepEquals(response, resultBody)).then(done())
+    })
+
+    it('should return the server response json when content type is json with encoding and no white space before charset', done => {
+        const resultBody = {foo: 'bar'}
+        const response = {
+            headers: {
+                'content-type': 'application/json;charset=utf-8'
+            },
+            body: resultBody
+        }
+
+        fetchMock.get('https://test.com/molgenis-test/get-something', response)
+        const get = api.get('https://test.com/molgenis-test/get-something')
+
+        get.then(response => assertDeepEquals(response, resultBody)).then(done())
     })
 
     it('should reject the server response when response type is not json and not ok', done => {


### PR DESCRIPTION
+
allow Upper case + allow double quotes

     text/html;charset=utf-8
     text/html;charset=UTF-8
     Text/HTML;Charset="utf-8"
     text/html; charset="utf-8"